### PR TITLE
Work with zh_CN

### DIFF
--- a/gengogettext.py
+++ b/gengogettext.py
@@ -73,9 +73,14 @@ def check_entry(lang, entry):
         'tier': 'standard',
         'purpose': 'Web localization',
     }
-    if lang == 'nb':
+
+    job['lc_tgt'] = job['lc_tgt'].replace('_', '-').lower()
+    if job['lc_tgt'] == 'zh-cn':
+        job['lc_tgt'] = 'zh'
+    elif job['lc_tgt'] == 'nb':
         job['lc_tgt'] = 'no'
         job['comment'] += u'\nNorwegian Bokmål'
+
     if entry.msgstr:
         job['comment'] += ('\nFuzzy translation. Previous translation was:\n' +
                            entry.msgstr)
@@ -173,6 +178,8 @@ def update_db():
         lang = job_data['lc_tgt']
         if lang == 'no':
             lang = 'nb'
+        if lang == 'zh':
+            lang = 'zh_CN'
         job = Job(
             id=job_data['job_id'],
             order_id=job_data['order_id'],
@@ -213,6 +220,8 @@ def update_statuses():
             job.lang = job_data['lc_tgt']
             if job.lang == 'no':
                 job.lang = 'nb'
+            if job.lang == 'zh':
+                job.lang = 'zh_CN'
             fix_translation(job)
             job.save()
 

--- a/tests/test_gengogettext.py
+++ b/tests/test_gengogettext.py
@@ -136,3 +136,26 @@ class TestTranslationChecks(unittest.TestCase):
         self.assertFalse(self.check_translation(
             'House &amp; Garden',
             'Casa &amp； Giardino'))
+
+
+class TestLanguageMangling(unittest.TestCase):
+    def test_unmangled_locale_to_gengo(self):
+        self.assertEqual(gengogettext.locale_to_gengo_language('it'),
+                         ('it', None))
+
+    def test_unmangled_gengo_to_locale(self):
+        self.assertEqual(gengogettext.gengo_language_to_locale('it'), 'it')
+
+    def test_mangle_bokmal_to_gengo(self):
+        self.assertEqual(gengogettext.locale_to_gengo_language('nb'),
+                         ('no', u'Norwegian Bokmål'))
+
+    def test_mangle_bokmal_to_locale(self):
+        self.assertEqual(gengogettext.gengo_language_to_locale('no'), 'nb')
+
+    def test_mangle_chinese_to_gengo(self):
+        self.assertEqual(gengogettext.locale_to_gengo_language('zh_CN'),
+                         ('zh', u'Simplified Chinese'))
+
+    def test_mangle_chinese_to_locale(self):
+        self.assertEqual(gengogettext.gengo_language_to_locale('zh'), 'zh_CN')


### PR DESCRIPTION
Allow us to use `zh_CN` as our Traditional Chinese locale dir name.

Also, cleanups, and tests.