### PR TITLE
Add support for projects which use JSON i18n approach

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,18 @@ Create Gengo translation jobs using a gettext catalog.
 * Configure projects
   * `cp projects.sample.ini projects.ini`
 * Run `./gengogettext.py`
+
+## Projects configuration
+
+We use two i18n approaches in our applications: gettext and JSON based translations.
+
+Every project, no matter which i18n approach it uses, can be configured with the following options:
+* `languages` - (_string_) a list of languages separated by space
+* `edit_jobs` - (_boolean_) if truthy, additional ["Edit" service](https://support.gengo.com/hc/en-us/articles/360001123788-What-are-Edit-jobs-) will be ordered for each job
+
+Configuration options required by gettext projects:
+* `domains` - (_string_) a list of gettext domains separated by space
+* `<domain-name>` - (_string_) a directory path where .po file for given domain is stored
+
+Configuration option required by projects with JSON i18n approach:
+* `locale_dir` - (_string_) a directory path where JSON files with source strings and translations are stored

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Gengo Gettext
 =============
 
-Create Gengo translation jobs using a gettext catalog.
+Create Gengo translation jobs using a gettext catalog or JSON files.
 
 ## Getting Started
 

--- a/gengogettext.py
+++ b/gengogettext.py
@@ -79,8 +79,6 @@ def check_entry(lang, entry, edit_jobs):
     # Translation in progress
     job = Job.find(lang, entry.msgid)
     if job:
-        if DEBUG:
-            print 'Skipping...'
         if job.status == 'approved':
             entry.msgstr = job.translation
             if 'fuzzy' in entry.flags:
@@ -123,7 +121,7 @@ def walk_po_file(locale_dir, lang, domain, edit_jobs):
         return
     po = polib.pofile(filename)
     updated = False
-    print 'Creating jobs',
+    print 'Creating jobs for {} locale'.format(lang),
     sys.stdout.flush()
     for entry in po:
         if entry.obsolete:
@@ -137,6 +135,7 @@ def walk_po_file(locale_dir, lang, domain, edit_jobs):
             sys.stdout.write('.')
             sys.stdout.flush()
     if updated:
+        print '\nSaving approved messages'
         po.save()
     print
 
@@ -380,7 +379,7 @@ def walk_json_file(source_messages, language, locale_dir, edit_jobs):
     if DEBUG:
         print 'Processing %s' % filename
     translations = open_or_create_json_file(filename)
-    print 'Creating jobs',
+    sys.stdout.write('Creating jobs for "{}" locale'.format(language))
     sys.stdout.flush()
 
     for message in source_messages:
@@ -398,6 +397,7 @@ def walk_json_file(source_messages, language, locale_dir, edit_jobs):
         sys.stdout.write('.')
         sys.stdout.flush()
     if updated:
+        print '\nSaving approved messages'
         write_json_file(filename, translations)
     print
 
@@ -464,6 +464,7 @@ def main(**kwargs):
 
     jobs = []
     for project in projects:
+        print '\nProcessing "{}" project'.format(project)
         languages = args.languages or config.get(project, 'languages').split()
         edit_jobs = config.getboolean(project, 'edit_jobs')
         try:
@@ -483,6 +484,7 @@ def main(**kwargs):
                     )
 
     if DEBUG:
+        print '{} new jobs'.format(len(jobs))
         print json.dumps(jobs, indent=2)
     if jobs:
         if quote_jobs(jobs) > MAX_COST:

--- a/gengogettext.py
+++ b/gengogettext.py
@@ -12,6 +12,7 @@ import os
 import re
 import sys
 import time
+from decimal import Decimal
 
 from gengo import Gengo, GengoError
 import polib
@@ -147,7 +148,7 @@ def quote_jobs(jobs):
     credits = 0
     for job in r['response']['jobs']:
         currency = job['currency']
-        credits += float(job['credits'])
+        credits += Decimal(job['credits'])
     print 'Cost: %s %0.2f' % (currency, credits)
     return credits
 

--- a/projects.sample.ini
+++ b/projects.sample.ini
@@ -2,16 +2,21 @@
 languages: nb
 domains: messages javascript
 yola_base: /home/stacey/git/yola
+edit_jobs: false
 
 [GLOBAL]
 max_cost: 10
 comment: Style Guide: <a href="http://goo.gl/YmtjzB"> http://goo.gl/YmtjzB </a><br> Yola terms: <a href="http://goo.gl/yfiQEJ"> http://goo.gl/yfiQEJ </a><br>Glossary: <a href="http://goo.gl/Lqb9G4"> http://goo.gl/Lqb9G4 </a>.
 
-[appfoo]
+[gettext-app]
 domains: django javascript
 root: %(yola_base)s/appfoo
 django: %(root)s/appfoo/locale
 javascript: %(root)s/appfoo/static/locale
+edit_jobs: true
+
+[app-with-json-translations]
+locale_dir: %(yola_base)s/yola-editor/locale
 
 [otherapp]
 root: %(yola_base)s/otherapp


### PR DESCRIPTION
Closes https://github.com/yola/production/issues/5831
See https://github.com/yola/production/issues/5757 for more details

I have not found a way to check in Sandbox UI if "edit service" is ordered for jobs. But there is a difference in price when we add "edit service" to each job. 
For example, an order with "edit service" costs USD 8.59. And order with the same 6 strings without "edit service" costs USD 5.72.

I've decided to keep gettext and JSON translations in the same script. I find it convenient to be able to order translations for different projects using a single script. 

I think now it makes sense to give a more general name to the repo. Maybe `gengo-translator`, `yola-gengo`, maybe better ideas? 
